### PR TITLE
Add FilterPackageName

### DIFF
--- a/src/main/java/com/openpojo/reflection/filters/FilterPackageName.java
+++ b/src/main/java/com/openpojo/reflection/filters/FilterPackageName.java
@@ -1,0 +1,35 @@
+package com.openpojo.reflection.filters;
+
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.PojoClassFilter;
+
+/**
+ * This class filters out any classes that package name doesn't contain the provide string.
+ *
+ * @author ohiocowboy
+ */
+public class FilterPackageName implements PojoClassFilter
+{
+    private String packageName;
+
+    public FilterPackageName(String packageName)
+    {
+        this.packageName = packageName;
+    }
+
+    public boolean include(PojoClass pojoClass)
+    {
+        Package aPackage = pojoClass.getClazz().getPackage();
+        return contains(aPackage.getName(), packageName);
+    }
+
+    private static boolean contains(CharSequence seq, CharSequence searchSeq)
+    {
+        return seq != null && searchSeq != null && indexOf(seq, searchSeq, 0) >= 0;
+    }
+
+    private static int indexOf(CharSequence cs, CharSequence searchChar, int start)
+    {
+        return cs.toString().indexOf(searchChar.toString(), start);
+    }
+}

--- a/src/test/java/com/openpojo/reflection/filters/FilterPackageNameTest.java
+++ b/src/test/java/com/openpojo/reflection/filters/FilterPackageNameTest.java
@@ -1,0 +1,40 @@
+package com.openpojo.reflection.filters;
+
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.impl.PojoClassFactory;
+import com.openpojo.validation.affirm.Affirm;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * @author ohiocowboy
+ */
+public class FilterPackageNameTest
+{
+    @Test
+    public void testNonFilteredPackageNameSize()
+    {
+        List<PojoClass> pojoClasses = PojoClassFactory
+                .getPojoClassesRecursively("com.openpojo", null);
+        Affirm.affirmEquals("Classes added / removed?", 751, pojoClasses.size());
+
+        pojoClasses = PojoClassFactory
+                .getPojoClassesRecursively("com.openpojo", new FilterPackageName("sampleclasses"));
+        Affirm.affirmEquals("Classes added / removed?", 140, pojoClasses.size());
+    }
+
+    @Test
+    public void testVerifyPackageNames()
+    {
+        String packageName = "sampleclasses";
+        List<PojoClass> pojoClasses = PojoClassFactory
+                .getPojoClassesRecursively("com.openpojo", new FilterPackageName(packageName));
+        for (PojoClass pojoClass : pojoClasses)
+        {
+            Package aPackage = pojoClass.getClazz().getPackage();
+            Affirm.affirmTrue(String.format("[%s] has correct string in package", pojoClass),
+                    aPackage.getName().contains(packageName));
+        }
+    }
+}


### PR DESCRIPTION
The use of this filter is so that in conjunction with `PojoClassFactory.getPojoClassesRecursively` you can pass the root package and then filter based on package name for instance of "model" anywhere.

package
foo.bar -> excluded classes
foo.bar.model -> included classes
foo.bar.server -> excluded classes