### PR TITLE
Added ToStringTester

### DIFF
--- a/src/main/java/com/openpojo/validation/test/impl/ToStringTester.java
+++ b/src/main/java/com/openpojo/validation/test/impl/ToStringTester.java
@@ -1,0 +1,57 @@
+package com.openpojo.validation.test.impl;
+
+import com.openpojo.reflection.PojoClass;
+import com.openpojo.reflection.PojoField;
+import com.openpojo.validation.affirm.Affirm;
+import com.openpojo.validation.test.Tester;
+import com.openpojo.validation.utils.ValidationHelper;
+
+/**
+ * 
+ * This tester ensures the toString based on the object Identity is used properly.
+ * 
+ * This Tester is NOT thread safe.
+ * 
+ * @author Kleeven81
+ *
+ */
+public class ToStringTester implements Tester {
+
+	public void run(final PojoClass pojoClass) {
+		final Object completeClassInstance = ValidationHelper.getMostCompleteInstance(pojoClass);
+		checkToString(pojoClass, completeClassInstance);
+
+		final Object basicClassInstance = ValidationHelper.getBasicInstance(pojoClass);
+		checkToString(pojoClass, basicClassInstance);
+
+	}
+
+	private void checkToString(final PojoClass pojoClass, final Object instance) {
+		StringBuilder expectedToString = new StringBuilder(pojoClass.getName());
+		expectedToString.append(" [@").append(Integer.toHexString(System.identityHashCode(instance))).append(':');
+		boolean firstField = true;
+		for (final PojoField fieldEntry : pojoClass.getPojoFields()) {
+			if (!firstField) {
+				expectedToString.append(',');
+			} else {
+				firstField = false;
+			}
+			expectedToString.append(' ');
+			expectedToString.append(fieldEntry.getName());
+			expectedToString.append('=');
+			Object entry = fieldEntry.get(instance);
+			if (entry != null) {
+				expectedToString.append(entry.toString());
+			} else {
+				expectedToString.append("null");
+			}
+		}
+		expectedToString.append(']');
+		String expected = expectedToString.toString();
+		String actual = instance.toString();
+		Affirm.affirmEquals(
+				String.format("toString did not return expected string for class '%s'.", pojoClass.getName()),
+				expected, actual);
+	}
+
+}

--- a/src/test/java/com/openpojo/validation/test/impl/ToStringTesterTest.java
+++ b/src/test/java/com/openpojo/validation/test/impl/ToStringTesterTest.java
@@ -1,0 +1,24 @@
+package com.openpojo.validation.test.impl;
+
+import org.junit.Test;
+
+import com.openpojo.validation.rule.impl.CommonCode;
+import com.openpojo.validation.test.Tester;
+import com.openpojo.validation.test.impl.sampleclasses.ABusinessPojoDispatchingToString;
+import com.openpojo.validation.test.impl.sampleclasses.ABusinessPojoNotDispatchingEquals;
+import com.openpojo.validation.test.impl.sampleclasses.ABusinessPojoNotDispatchingToString;
+
+public class ToStringTesterTest {
+
+	Class<?>[] failClasses = new Class<?>[] { ABusinessPojoNotDispatchingToString.class,
+			ABusinessPojoNotDispatchingEquals.class };
+	Class<?>[] passClasses = new Class<?>[] { ABusinessPojoDispatchingToString.class };
+	Tester test = new ToStringTester();
+
+	@Test
+	public void testEvaluate() {
+		CommonCode.shouldPassTesterValidation(test, passClasses);
+		CommonCode.shouldFailTesterValidation(test, failClasses);
+	}
+
+}

--- a/src/test/java/com/openpojo/validation/test/impl/sampleclasses/ABusinessPojoDispatchingToString.java
+++ b/src/test/java/com/openpojo/validation/test/impl/sampleclasses/ABusinessPojoDispatchingToString.java
@@ -1,0 +1,15 @@
+package com.openpojo.validation.test.impl.sampleclasses;
+
+import com.openpojo.business.BusinessIdentity;
+import com.openpojo.business.annotation.BusinessKey;
+
+public class ABusinessPojoDispatchingToString {
+
+	@BusinessKey
+	private String someString;
+
+	@Override
+	public String toString() {
+		return BusinessIdentity.toString(this);
+	}
+}

--- a/src/test/java/com/openpojo/validation/test/impl/sampleclasses/ABusinessPojoNotDispatchingToString.java
+++ b/src/test/java/com/openpojo/validation/test/impl/sampleclasses/ABusinessPojoNotDispatchingToString.java
@@ -1,0 +1,14 @@
+package com.openpojo.validation.test.impl.sampleclasses;
+
+import com.openpojo.business.annotation.BusinessKey;
+
+public class ABusinessPojoNotDispatchingToString {
+
+	@BusinessKey
+	private String someString;
+
+	@Override
+	public String toString() {
+		return someString;
+	}
+}


### PR DESCRIPTION
When working with openpojo I ran into the problem that the current Validator doesn't have any options to check the toString method when it is overridden with the BusinessIdentity.toString() method. Since we want to achieve a code coverage as high as possible I'd also want to test this method. In order to do this in a uniform way I've added a ToStringTester.

I think it would make a nice addition to the openpojo framework so users can easily achieve a meaningful 100% test coverage with little extra effort.
