### PR TITLE
Fixed creating subclasses containing protected methods

### DIFF
--- a/src/main/java/com/openpojo/reflection/java/bytecode/asm/SubClassCreator.java
+++ b/src/main/java/com/openpojo/reflection/java/bytecode/asm/SubClassCreator.java
@@ -67,7 +67,7 @@ class SubClassCreator extends ClassVisitor {
   public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
     LOGGER.debug("Method: " + name + " access:" + access + " desc:" + desc + " signature:" + signature + " exceptions:" +
         Arrays.toString(exceptions));
-    if (name.equals("<init>") && access == ACC_PUBLIC || access == ACC_PROTECTED) {
+    if (name.equals("<init>") && (access == ACC_PUBLIC || access == ACC_PROTECTED)) {
       MethodVisitor mv = cw.visitMethod(access, name, desc, signature, exceptions);
       int counter = getParameterCount(desc);
       // wire constructor method to super


### PR DESCRIPTION
Came across this when I had a POJO with a protected method (canEqual generated by Lombok). OpenPojo erroneously tries to copy regular protected methods as constructors of the subclass. In my case this caused a `java.lang.ClassFormatError`, because canEqual returns a boolean.