### PR TITLE
Lookup implementing interfaces in parent classes.

### DIFF
--- a/src/main/java/com/openpojo/validation/rule/impl/NoFieldShadowingRule.java
+++ b/src/main/java/com/openpojo/validation/rule/impl/NoFieldShadowingRule.java
@@ -88,10 +88,20 @@ public class NoFieldShadowingRule implements Rule {
 
   private boolean isSerializable(PojoField field, PojoClass pojoClass) {
     return field.getName().equals(SERIAL_VERSION_UID_FIELD_NAME)
-        && pojoClass.getInterfaces().contains(serializablePojoClass)
+        && isImplementingInterfaceRecursive(pojoClass)
         && field.getType().equals(SERIAL_VERSION_UID_FIELD_TYPE);
   }
 
+  private boolean isImplementingInterfaceRecursive(PojoClass pojoClass) {
+      if (pojoClass.getInterfaces().contains(serializablePojoClass)) {
+          return true;
+      }
+      if (pojoClass.getSuperClass() != null) {
+          return isImplementingInterfaceRecursive(pojoClass.getSuperClass());
+      }
+      return false;
+  }
+  
   private boolean contains(final String fieldName, final List<PojoField> pojoFields) {
     for (final PojoField pojoField : pojoFields) {
       if (pojoField.getName().equals(fieldName)) {

--- a/src/test/java/com/openpojo/validation/rule/impl/NoFieldShadowingRuleTest.java
+++ b/src/test/java/com/openpojo/validation/rule/impl/NoFieldShadowingRuleTest.java
@@ -28,6 +28,7 @@ import com.openpojo.validation.ValidatorBuilder;
 import com.openpojo.validation.rule.impl.sampleclasses.NoShadowAChildWithFieldShadowing;
 import com.openpojo.validation.rule.impl.sampleclasses.NoShadowAParentClassWithOneField;
 import com.openpojo.validation.rule.impl.sampleclasses.NoShadowSerializableChild;
+import com.openpojo.validation.rule.impl.sampleclasses.NoShadowSerializableChildWithoutImplementationOfSerializableInterface;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,6 +131,11 @@ public class NoFieldShadowingRuleTest {
   @Test
   public void shouldNotAddserialVersionUIDToShadowFieldList() {
     validator.validate(PojoClassFactory.getPojoClass(NoShadowSerializableChild.class));
+  }
+  
+  @Test
+  public void shouldNotAddserialVersionUIDFromChildWithoutInterfaceToShadowFieldList() {
+    validator.validate(PojoClassFactory.getPojoClass(NoShadowSerializableChildWithoutImplementationOfSerializableInterface.class));
   }
 
 

--- a/src/test/java/com/openpojo/validation/rule/impl/sampleclasses/NoShadowSerializableChildWithoutImplementationOfSerializableInterface.java
+++ b/src/test/java/com/openpojo/validation/rule/impl/sampleclasses/NoShadowSerializableChildWithoutImplementationOfSerializableInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2017 Osman Shoukry
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied.
+ *
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.openpojo.validation.rule.impl.sampleclasses;
+
+/**
+ * @author hvoss
+ */
+public class NoShadowSerializableChildWithoutImplementationOfSerializableInterface extends NoShadowSerializableParent {
+  private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
Fixes an error in the the NoFieldShadowingRule. The field
serialVersionUID does not shadow a parent field.